### PR TITLE
Use absolute URL instead of relative

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,7 @@
       const target = event.target;
       if (target.tagName !== 'IMG') { return }
       if (target.src.includes('static/speaker-male-placeholder.jpg')) { return }
-      target.src = 'static/speaker-male-placeholder.jpg';
+      target.src = '/static/speaker-male-placeholder.jpg';
     }, true);
   })(window, document);
 </script>


### PR DESCRIPTION
Fix issue w/ placeholders being broken on 'EN' page due to 404 on wrong asset path